### PR TITLE
feature: general variable print function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ A simple Lua debugger supporting breakpoints
 一个简单的Lua调试器，支持断点调试
 
 - ch01: minimal implementation of breakpoints 断点的最小实现
+- ch02: general variable print function 通用变量打印函数

--- a/ch02/mydebug.lua
+++ b/ch02/mydebug.lua
@@ -44,7 +44,58 @@ local function removebreakpoint(id)
 end
 
 
+-- get variable from local, upvalue or _ENV
+-- modified from "Programming in Lua Fourth edition"
+local function _getvarvalue (name, level, isenv)
+    local value
+    local found = false
+
+    -- + 1 to correct the level to include _getvarvalue itself,
+    -- default by 5: getvarvalue, debug mainchunk, debug.debug, hook and foo
+    level = (level or 5) + 1
+    -- try local vars
+    for i = 1, math.huge do
+        local n, v = debug.getlocal(level, i)
+        if not n then break end
+        if n == name then
+            value = v
+            found = true
+            -- we didn't break here in order to get the local var with max index
+        end
+    end
+    if found then return "local", value end
+
+    -- try upvalues
+    local func = debug.getinfo(level, "f").func
+    for i = 1, math.huge do
+        local n, v = debug.getupvalue(func, i)
+        if not n then break end
+        if n == name then return "upvalue", v end
+    end
+
+    if isenv then return "noenv" end	-- avoid dead loop
+
+    -- try to get from _ENV
+    local _, env = _getvarvalue("_ENV", level, true)
+    if env then
+        return "global", env[name]
+    else
+        return "noenv"
+    end
+end
+
+-- wrap _getvarvalue, to print value
+local function getvarvalue (name, level)
+    local where, value = _getvarvalue(name, level)
+    if value then
+        print(where, value)
+    else
+        print(name, "not found")
+    end
+end
+
 return {
     setbreakpoint = setbreakpoint,
     removebreakpoint = removebreakpoint,
+    getvarvalue = getvarvalue,
 }

--- a/ch02/mydebug.lua
+++ b/ch02/mydebug.lua
@@ -51,8 +51,7 @@ local function _getvarvalue (name, level, isenv)
     local found = false
 
     -- + 1 to correct the level to include _getvarvalue itself,
-    -- default by 5: getvarvalue, debug mainchunk, debug.debug, hook and foo
-    level = (level or 5) + 1
+    level = (level or 1) + 1
     -- try local vars
     for i = 1, math.huge do
         local n, v = debug.getlocal(level, i)
@@ -86,6 +85,9 @@ end
 
 -- wrap _getvarvalue, to print value
 local function getvarvalue (name, level)
+    -- default by 1
+    -- plus 4 to include getvarvalue, debug mainchunk, debug.debug, hook
+    level = (level or 1) + 4
     local where, value = _getvarvalue(name, level)
     if value then
         print(where, value)

--- a/ch02/test.lua
+++ b/ch02/test.lua
@@ -1,6 +1,7 @@
 local mydebug = require "mydebug"
 local setbp = mydebug.setbreakpoint
 local rmbp = mydebug.removebreakpoint
+getv = mydebug.getvarvalue
 
 g = 1
 
@@ -16,18 +17,18 @@ local function bar (n)
     n = n + 1
 end
 
-local id1 = setbp(foo, 11)
-local id2 = setbp(bar, 16)
+local id1 = setbp(foo, 12)
+local id2 = setbp(bar, 17)
 
 foo(10)
 bar(10)
 
-rmbp(id1)
+rmbp(id2)
 
 foo(20)
 bar(20)
 
-rmbp(id2)
+rmbp(id1)
 
 foo(30)
 bar(30)


### PR DESCRIPTION
Add a general variable print interface function `getvarvalue`

`syntax: mydebug.getvarvalue(name, level)`

`name` is a string of variable name, `level` is a number which is 1 by default (denotes the level of function which is set breakpoint)